### PR TITLE
fix: plugin type is not part of the name

### DIFF
--- a/generators/app/index.ts
+++ b/generators/app/index.ts
@@ -96,7 +96,7 @@ export default class VerdaccioPluginGenerator extends Generator {
         // To access props later use this.props.someAnswer;
         // @ts-ignore
         this.props = _props;
-        const { name, pluginType, githubUsername } = _props;
+        const { name, githubUsername } = _props;
         // @ts-ignore
         this.props.license = "MIT";
         if (githubUsername) {
@@ -105,7 +105,7 @@ export default class VerdaccioPluginGenerator extends Generator {
         }
 
         // @ts-ignore
-        this.projectName = `verdaccio-${pluginType}-${name}`;
+        this.projectName = `verdaccio-${name}`;
 
         // @ts-ignore
         this.destinationPathName = resolve(this.projectName);

--- a/test/generator-template.test.js
+++ b/test/generator-template.test.js
@@ -15,7 +15,7 @@ describe('template generator', function() {
   const  license = 'MIT';
   const  repository = 'verdaccio/generator-test';
   const getBuildAsset = (tempRoot, pluginType, item) => {
-    const prefixPath = path.join(tempRoot, `/verdaccio-${pluginType}-${name}`);
+    const prefixPath = path.join(tempRoot, `/verdaccio-${name}`);
     return `${prefixPath}/${item}`;
   }
 


### PR DESCRIPTION
If we use the plugin type as part of the name, then we must use the pluging type in the config.yaml and looks pretty odd

example:

currently

```
auth:
  htpasswd:
    file: ./htpasswd
```

without this fix

```
auth:
  auth-htpasswd:
    file: ./htpasswd
```